### PR TITLE
ci: remove paths-filter change detection from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,40 +15,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  changes:
-    name: Detect Changes
-    runs-on: ubuntu-latest
-    outputs:
-      code: ${{ steps.filter.outputs.code }}
-      docs: ${{ steps.filter.outputs.docs }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Check for file changes
-        uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          filters: |
-            code:
-              - 'src/**'
-              - 'public/**'
-              - 'package.json'
-              - 'pnpm-lock.yaml'
-              - 'tsconfig.json'
-              - '*.config.{ts,js,cjs,mjs}'
-              - '.github/workflows/**'
-              - '.github/actions/setup/**'
-              - '.node-version'
-            docs:
-              - '**/*.md'
-              - 'docs/**'
-
   quality-checks:
     name: Code Quality Checks
     runs-on: ubuntu-latest
-    needs: changes
-    if: needs.changes.outputs.code == 'true'
 
     steps:
       - name: Checkout code
@@ -85,8 +54,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [changes, quality-checks]
-    if: needs.changes.outputs.code == 'true'
+    needs: quality-checks
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Remove the dorny/paths-filter-based changes job and run all checks unconditionally on every push/PR.

- Drop the changes job entirely
- Remove conditional if expressions from quality-checks and build
- Update build's needs to quality-checks only (drop changes dep)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes

This PR removes the `dorny/paths-filter` based change detection from the CI workflow and ensures all checks run unconditionally on every push and pull request.

### Modified Files

**.github/workflows/ci.yml**

- Removed the `changes` job entirely, which previously used `dorny/paths-filter` to detect code changes
- Removed the conditional `if: needs.changes.outputs.code == 'true'` from the `quality-checks` job
- Removed the `needs: changes` dependency from the `quality-checks` job
- Updated the `build` job's `needs` field from `[changes, quality-checks]` to `quality-checks`, removing the dependency on the change detection job

### Impact

The workflow now runs quality checks and build jobs unconditionally on every push and pull request, rather than skipping them based on path-based change detection. The `build` job maintains its sequential dependency on `quality-checks`, ensuring proper job ordering.

**Lines changed: +1/-33**

<!-- end of auto-generated comment: release notes by coderabbit.ai -->