### PR TITLE
feat(middleware): add temporary redirect to vancura.dev

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,6 +4,16 @@ import { detectLocaleFromHostname, getLocaleFromCookie } from '@i18n/utils';
 import type { Locale } from '@type/locale';
 import { defineMiddleware } from 'astro:middleware';
 
+const OCTET = '(?:25[0-5]|2[0-4]\\d|1\\d{2}|[1-9]?\\d)';
+const IPV4_LOOPBACK_RE = new RegExp(`^127\\.${OCTET}\\.${OCTET}\\.${OCTET}$`);
+
+function isLocalhost(hostname: string): boolean {
+    if (hostname === 'localhost' || hostname.endsWith('.localhost')) return true;
+    if (hostname === '::1' || hostname === '[::1]') return true;
+
+    return IPV4_LOOPBACK_RE.test(hostname);
+}
+
 const ERROR_STATUS_MAP: Record<string, number> = {
     '/404': 404,
     '/500': 500,
@@ -42,7 +52,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
     // TEMPORARY: Redirect all traffic to vancura.dev
     const incomingUrl = new URL(context.request.url);
 
-    if (incomingUrl.hostname !== 'localhost' && !incomingUrl.hostname.startsWith('127.')) {
+    if (!isLocalhost(incomingUrl.hostname)) {
         return context.redirect('https://vancura.dev', 302);
     }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -39,6 +39,13 @@ function isErrorPage(pathname: string): boolean {
 }
 
 export const onRequest = defineMiddleware(async (context, next) => {
+    // TEMPORARY: Redirect all traffic to vancura.dev
+    const incomingUrl = new URL(context.request.url);
+
+    if (incomingUrl.hostname !== 'localhost' && !incomingUrl.hostname.startsWith('127.')) {
+        return context.redirect('https://vancura.dev', 302);
+    }
+
     // Redirect ambilab.cz to ambilab.com, preserving path and query (AL-318)
     const url = new URL(context.request.url);
     const host = url.hostname.toLowerCase().replace(/^www\./, '');


### PR DESCRIPTION
Redirect all non-localhost traffic to https://vancura.dev with a 302 (temporary) status. Localhost and 127.* are excluded so local development continues to work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changes

Adds a temporary redirect in middleware that intercepts all non-localhost traffic and redirects it to https://vancura.dev with HTTP 302.

## Implementation details

- Introduces an internal isLocalhost() helper that:
  - Accepts "localhost" and ".localhost" subdomains
  - Validates IPv4 loopback via octet-aware regex for 127.0.0.0/8 (replacing the previous startsWith('127.') check)
  - Supports IPv6 loopback forms (::1 and [::1])
- Adds an early control-flow branch at the start of export const onRequest = defineMiddleware(...) that:
  - Constructs the request URL and checks the hostname with isLocalhost()
  - Immediately issues a 302 redirect to https://vancura.dev for non-localhost hosts
  - Runs before the existing ambilab.cz → ambilab.com redirect, locale/requestId initialization, next() invocation, and error-page (/500) handling
- Change set is internal only: no exported/public signatures were modified; only a non-exported helper and internal middleware logic were added.
- Commit metadata includes Co-Authored-By: Claude Opus 4.6 and Signed-off-by: Vaclav Vancura.

Lines changed: +17/-0

Note: The redirect is marked as temporary in the code comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->